### PR TITLE
New onOpen/onClose behavior

### DIFF
--- a/src/test/scala/scalawebsocket/WebSocketSpec.scala
+++ b/src/test/scala/scalawebsocket/WebSocketSpec.scala
@@ -103,7 +103,7 @@ class WebSocketSpec extends BaseTest with Logging {
   }
 
   it should "remove specified onOpen handler" in {
-    def openHandler(ws: websocket.WebSocket) {
+    def openHandler(ws: WebSocket) {
       throw new IllegalStateException("This handler should be removed")
     }
     val handler = openHandler _
@@ -122,7 +122,7 @@ class WebSocketSpec extends BaseTest with Logging {
   }
 
   it should "remove specified onClose handler" in {
-    def closeHandler(ws: websocket.WebSocket) {
+    def closeHandler(ws: WebSocket) {
       throw new IllegalStateException("This handler should be removed")
     }
     val handler = closeHandler _


### PR DESCRIPTION
The onOpen handlers can be invoked before the WebSocket instance is fully initialized.  The ws value is set in open() when the future returned by execute() completes but the onOpen callback can be invoked before that.  This can result in a NullPointerException if a call is made to a method like sendText() in response to receiving an onOpen callback.

This pull request moves the invocation of the onOpen handlers into open() after the the ws value is initialized.  Also, the onOpen and onClose handlers now supply a scalawebsocket.WebSocket value as their parameter.  This prevents leaking the underlying AsyncHttpClient WebSocket value outside the implementation.
